### PR TITLE
Better commands

### DIFF
--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -163,7 +163,7 @@ server.PacketHandler = (c, p) => {
             IEnumerable<Client> search = server.Clients.Where(c => c.Connected &&
                 (c.Name.ToLower().StartsWith(arg.ToLower()) || (Guid.TryParse(arg, out Guid res) && res == c.Id)));
             if (!search.Any())
-                failToFind.Add(arg.ToLower()); //none found
+                failToFind.Add(arg); //none found
             else if (search.Count() > 1) {
                 Client? exact = search.FirstOrDefault(x => x.Name == arg);
                 if (!ReferenceEquals(exact, null)) {
@@ -174,7 +174,7 @@ server.PacketHandler = (c, p) => {
                         toActUpon.Add(exact);
                 }
                 else {
-                    ambig.Add((arg.ToLower(), search.Select(x => x.Name))); //more than one match
+                    ambig.Add((arg, search.Select(x => x.Name))); //more than one match
                     foreach (var rem in search.ToList()) //need copy because can't remove from list while iterating over it
                         toActUpon.Remove(rem);
                 }
@@ -203,7 +203,7 @@ CommandHandler.RegisterCommand("rejoin", args => {
     sb.Append(res.failToFind.Count > 0 ? "Failed to find matches for: " + string.Join(", ", res.failToFind.Select(x => $"\"{x.ToLower()}\"")) + "\n" : "");
     if (res.ambig.Count > 0) {
         res.ambig.ForEach(x => {
-            sb.Append($"Ambiguous for {x.arg}: {string.Join(", ", x.amb.Select(x => $"\"{x}\""))}\n");
+            sb.Append($"Ambiguous for \"{x.arg}\": {string.Join(", ", x.amb.Select(x => $"\"{x}\""))}\n");
         });
         sb.Remove(sb.Length - 1, 1); //remove extra nl
     }
@@ -227,7 +227,7 @@ CommandHandler.RegisterCommand("crash", args => {
     sb.Append(res.failToFind.Count > 0 ? "Failed to find matches for: " + string.Join(", ", res.failToFind.Select(x => $"\"{x.ToLower()}\"")) + "\n" : "");
     if (res.ambig.Count > 0) {
         res.ambig.ForEach(x => {
-            sb.Append($"Ambiguous for {x.arg}: {string.Join(", ", x.amb.Select(x => $"\"{x}\""))}\n");
+            sb.Append($"Ambiguous for \"{x.arg}\": {string.Join(", ", x.amb.Select(x => $"\"{x}\""))}\n");
         });
         sb.Remove(sb.Length - 1, 1); //remove extra nl
     }
@@ -252,6 +252,43 @@ CommandHandler.RegisterCommand("ban", args => {
         return "Usage: ban <* | !* (usernames to not ban...) | (usernames to ban...)>";
     }
 
+    #region Testing
+    //void TestAddClients()
+    //{
+    //    Client c1 = new Client(null!);
+    //    c1.Id = new Guid("00000000000000000000000000000000");
+    //    c1.Connected = true;
+    //    c1.Name = "Moo";
+    //    server.Clients.Add(c1);
+
+    //    Client c2 = new Client(null!);
+    //    c2.Id = new Guid("00000000000000000000000000000001");
+    //    c2.Connected = true;
+    //    c2.Name = "Moomoss";
+    //    server.Clients.Add(c2);
+
+    //    Client c3 = new Client(null!);
+    //    c3.Id = new Guid("00000000000000000000000000000002");
+    //    c3.Connected = true;
+    //    c3.Name = "mo";
+    //    server.Clients.Add(c3);
+
+    //    Client c4 = new Client(null!);
+    //    c4.Id = new Guid("00000000000000000000000000000003");
+    //    c4.Connected = true;
+    //    c4.Name = "Bar";
+    //    server.Clients.Add(c4);
+
+    //    Client c5 = new Client(null!);
+    //    c5.Id = new Guid("00000000000000000000000000000004");
+    //    c5.Connected = true;
+    //    c5.Name = "Foo";
+    //    server.Clients.Add(c5);
+    //}
+
+    //TestAddClients();
+    #endregion
+
     var res = MultiUserCommandHelper(args);
 
     StringBuilder sb = new StringBuilder();
@@ -259,7 +296,7 @@ CommandHandler.RegisterCommand("ban", args => {
     sb.Append(res.failToFind.Count > 0 ? "Failed to find matches for: " + string.Join(", ", res.failToFind.Select(x => $"\"{x.ToLower()}\"")) + "\n" : "");
     if (res.ambig.Count > 0) {
         res.ambig.ForEach(x => {
-            sb.Append($"Ambiguous for {x.arg}: {string.Join(", ", x.amb.Select(x => $"\"{x}\""))}\n");
+            sb.Append($"Ambiguous for \"{x.arg}\": {string.Join(", ", x.amb.Select(x => $"\"{x}\""))}\n");
         });
         sb.Remove(sb.Length - 1, 1); //remove extra nl
     }

--- a/Server/Server.cs
+++ b/Server/Server.cs
@@ -170,7 +170,6 @@ public class Server {
                     ConnectPacket connect = new ConnectPacket();
                     connect.Deserialize(memory.Memory.Span[packetRange]);
                     lock (Clients) {
-                        client.Name = connect.ClientName;
                         if (Clients.Count(x => x.Connected) == Settings.Instance.Server.MaxPlayers) {
                             client.Logger.Error($"Turned away as server is at max clients");
                             memory.Dispose();
@@ -212,6 +211,7 @@ public class Server {
                                 throw new Exception($"Invalid connection type {connect.ConnectionType}");
                         }
 
+                        client.Name = connect.ClientName;
                         client.Connected = true;
                         if (firstConn) {
                             // do any cleanup required when it comes to new clients


### PR DESCRIPTION
Eg. if users "Moo", "Moomoss", "mo", "Bar", "Foo" are connected, guid's in order are 00...000, 00...001, 00...002, 00...003, 00...004,

ban !* mo
Banned: "Moo", "Moomoss", "Bar", "Foo"

ban !* mo isn't ambiguous because argument "mo" is an exact match for user "mo"

ban !* Mo
Banned: "Bar", "Foo"
Ambiguous for "Mo": "Moo", "Moomoss", "mo"

It tries to find exact match, but it cant so it finds case-insensitive matches and three are found (ambiguous), so none of the ambiguous users are banned

ban !* baz
Banned: "Moo", "Moomoss", "mo", "Bar", "Foo"
Failed to find matches for: "baz"

since no user exists with the name baz, it bans everyone except baz (which is everyone)

ban !* mo baz
Banned: "Moo", "Moomoss", "Bar", "Foo"
Failed to find matches for: "baz"

since it found "mo", it banned everyone except mo, and it couldn't find baz.

ban * still bans everyone

ban mo
Banned: "mo"

found an exact match for "mo" so it banned "mo"

ban Mo
Ambiguous for "Mo": "Moo", "Moomoss", "mo"

since it didn't find an exact match for "Mo" it tried case-insensitive/autocomplete, and it got ambiguous users (no action taken).

ban 00000000000000000000000000000004 mo
Banned: "Foo", "mo"

banned mo from "mo", "Foo" from guid

ban !* 00000000000000000000000000000002
Banned: "Moo", "Moomoss", "Bar", "Foo"

banned everyone except mo (with guid 00...002)